### PR TITLE
Change prop

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -228,6 +228,36 @@ const DemoPage = ({ className }) => {
             can overwrite that by passing an optional <code>style</code> object.
           </p>
           <p>Find all the available animations listed under Animations.</p>
+          
+          <h3>change</h3>
+          <p>
+            By default the animation is triggered when <code>children</code> change.
+            The default behavior can be overridden using the <code>change</code> property.
+            The animation will trigger when the provided value changes, instead of <code>children</code>.
+          </p>
+          <LazyLoad height={200}>
+            <div className="example">
+              <pre>
+                <code>{`
+<AnimateOnChange 
+  change={valueThatChangesOverTime}
+  animationIn="beat"
+  animationOut=""
+>
+  Static content
+</AnimateOnChange>`}</code>
+              </pre>
+              <div className="example-aoc-default">
+                <AnimateOnChange 
+                  change={randomWord}
+                  animationIn="beat" 
+                  animationOut="" 
+                >
+                  Static content
+                </AnimateOnChange>
+              </div>
+            </div>
+          </LazyLoad>
         </div>
         <div className="page-content">
           <h2>HideUntilLoaded</h2>

--- a/src/AnimateOnChange/AnimateOnChange.test.js
+++ b/src/AnimateOnChange/AnimateOnChange.test.js
@@ -75,7 +75,7 @@ describe('AnimateOnChange', () => {
 
   it('should not animate when animate is true when if content changes', () => {
     const component = mount(
-      <AnimateOnChange manual animate={false}>
+      <AnimateOnChange animate={false}>
         old
       </AnimateOnChange>
     )

--- a/src/AnimateOnChange/index.js
+++ b/src/AnimateOnChange/index.js
@@ -21,7 +21,7 @@ const AnimateOnChange = ({
   animationOut,
   children,
   durationOut,
-  manual,
+  change,
   style
 }) => {
   const [animation, setAnimation] = useState('')
@@ -51,13 +51,11 @@ const AnimateOnChange = ({
         clearTimeout(timeout)
       }
     },
-    [children]
+    [change || children]
   )
 
   const styles = {
     display: 'inline-block',
-    transition: `opacity ${durationOut}ms ease-out`,
-    opacity: animation === 'out' ? 0 : 1,
     ...style
   }
 
@@ -79,12 +77,14 @@ AnimateOnChange.propTypes = {
   durationOut: PropTypes.number,
   animationIn: PropTypes.string,
   animationOut: PropTypes.string,
-  manual: PropTypes.bool,
+  change: PropTypes.any,
   style: PropTypes.object
 }
 
 AnimateOnChange.defaultProps = {
-  durationOut: 200
+  durationOut: 200,
+  animationIn: 'fadeIn',
+  animationOut: 'fadeOut'
 }
 
 AnimateOnChange.displayName = 'AnimateOnChange'

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -35,5 +35,6 @@ export const animations = {
   bounceIn: `pop-in 300ms ${easings.easeOutBack} forwards`,
   bounceOut: `pop-out 300ms ${easings.easeInBack} forwards`,
   slideIn: `slide-in 500ms ${easings.easeInOutBack} forwards`,
-  slideOut: `slide-out 350ms ${easings.easeOutBack} forwards`
+  slideOut: `slide-out 350ms ${easings.easeOutBack} forwards`,
+  beat: `beat 500ms ${easings.easeInOutQuad} forwards`
 }

--- a/src/theme/keyframes.css
+++ b/src/theme/keyframes.css
@@ -78,3 +78,15 @@
     transform: translateY(-100%);
   }
 }
+
+@keyframes beat {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1)
+  }
+}


### PR DESCRIPTION
Hey Donovan, I'm Simone 🤝 

So I was going to try to implement the feature which allows triggering the animation when something else changes, not necessarily children. 

The use case is: I have static content which I don't want to change, I just want to animate it when something else changes. It turns out that doing so is super easy using the 2nd argument of the `use[Layout]Effect` hook.

Now, what I had to deal with once I did that, is that the assumption the `AnimateOnChange` component has is that something disappears and then reappears, which is not the scenario for this feature.

In fact, there is an opacity transition always applied, which doesn't fit in this case. I worked around that by replacing the transition with default values of the `animationIn` and `animationOut` props, which seems to work fine.

Now, I'm submitting this PR anyway, but I have some doubts that the API of the `AnimateOnChange` component is a good fit for this use case, the whole "in" and "out" concepts don't really fit in my scenario.

Still, what I really like about this component over, say, https://www.npmjs.com/package/react-animate-on-change, is that you can use it out of the box, so if we could find a way to provide an API which doesn't necessarily imply hiding and displaying something, it would be great. This PR, more than something I'd like to see merged, is mostly a base to work on.