### PR TITLE
Fixing the visual glitch on the animated emoji in the header

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -112,7 +112,11 @@ const DemoPage = ({ className }) => {
         <div className="page-content">
           <h1>
             React Animation{' '}
-            <AnimateOnChange animationOut="bounceOut" animationIn="bounceIn">
+            <AnimateOnChange
+              animationOut="bounceOut"
+              animationIn="bounceIn"
+              className="title-emoji"
+            >
               {randomEmoji}
             </AnimateOnChange>
           </h1>
@@ -516,10 +520,18 @@ const StyledDemoPage = styled(DemoPage)`
     color: rgba(255, 255, 255, 0.9);
     font-size: 34px;
     margin-top: -54px;
+    margin-bottom: 10px;
 
     @media ${() => breakpoints.desktop} {
       font-size: 64px;
-      margin-top: -60px;
+      margin-top: -68px;
+    }
+
+    .title-emoji {
+      @media ${() => breakpoints.desktop} {
+        font-size: 52px;
+        line-height: 72px;
+      }
     }
   }
 


### PR DESCRIPTION
This patches the size of the emoji so that it no longer clips when animated. Tested in Chrome / MacOS.

![screenshot 2019-02-07 at 14 56 36](https://user-images.githubusercontent.com/853536/52419750-9f9a9c80-2ae8-11e9-97b3-8058ef789e78.png)
