### PR TITLE
Fixes for issues #11, #12, #16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-animation",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Helpful animation components for adding movement to your React components",
   "main": "dist/react-animation.js",
   "files": [

--- a/src/AnimateOnChange/AnimateOnChange.test.js
+++ b/src/AnimateOnChange/AnimateOnChange.test.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { act } from 'react-dom/test-utils'
 import { mount } from 'enzyme'
 import AnimateOnChange from './'
-
+/*
 jest.useFakeTimers()
-
+*/
 describe('AnimateOnChange', () => {
   it('should render child value', () => {
     const component = mount(<AnimateOnChange>123</AnimateOnChange>)
@@ -44,6 +44,7 @@ describe('AnimateOnChange', () => {
 
   it('should animate then change content when children changes', () => {
     const component = mount(<AnimateOnChange>old</AnimateOnChange>)
+    component.simulate('transitionEnd');
     expect(component.find('span').get(0).props.style.opacity).toEqual(1)
     expect(component.text()).toEqual('old')
 
@@ -61,14 +62,17 @@ describe('AnimateOnChange', () => {
     expect(component.text()).toEqual('old')
 
     // Test opacity and new value after duration has passed
-
+/*
     act(() => {
       jest.runAllTimers()
     })
+*/
 
     act(() => {
       component.update()
     })
+    component.simulate('transitionEnd');
+
     expect(component.find('span').get(0).props.style.opacity).toEqual(1)
     expect(component.text()).toEqual('new')
   })
@@ -96,14 +100,15 @@ describe('AnimateOnChange', () => {
       expect.stringContaining('pop-out')
     )
     expect(component.text()).toEqual('old')
-
+/*
     act(() => {
       jest.runAllTimers()
     })
-
+*/
     act(() => {
       component.update()
     })
+    component.simulate('transitionEnd');
 
     expect(component.find('span').get(0).props.style.animation).toEqual(
       expect.stringContaining('pop-in')
@@ -132,14 +137,15 @@ describe('AnimateOnChange', () => {
     expect(component.find('span').get(0).props.style.animation).toEqual(
       expect.stringContaining('out test')
     )
-
+/*
     act(() => {
       jest.runAllTimers()
     })
-
+*/
     act(() => {
       component.update()
     })
+    component.simulate('transitionEnd');
 
     expect(component.find('span').get(0).props.style.animation).toEqual(
       expect.stringContaining('in test')
@@ -173,14 +179,15 @@ describe('AnimateOnChange', () => {
     expect(component.find('span').get(0).props.className).not.toEqual(
       expect.stringContaining(`${className}-in`)
     )
-
+/*
     act(() => {
       jest.runAllTimers()
     })
-
+*/
     act(() => {
       component.update()
     })
+    component.simulate('transitionEnd');
 
     expect(component.find('span').get(0).props.className).not.toEqual(
       expect.stringContaining(`${className}-out`)
@@ -219,14 +226,15 @@ describe('AnimateOnChange', () => {
     expect(component.find('span').get(0).props.className).not.toEqual(
       expect.stringContaining(`${className}-in`)
     )
-
+/*
     act(() => {
       jest.runAllTimers()
     })
-
+*/
     act(() => {
       component.update()
     })
+    component.simulate('transitionEnd');
 
     expect(component.find('span').get(0).props.className).not.toEqual(
       expect.stringContaining(`${className}-out`)
@@ -249,8 +257,9 @@ describe('AnimateOnChange', () => {
     act(() => {
       component.unmount()
     })
-
+/*
     expect(clearTimeout).toHaveBeenCalledTimes(1)
+*/
   })
 
   it('should accept custom styles', () => {

--- a/src/AnimateOnChange/AnimateOnChange.test.js
+++ b/src/AnimateOnChange/AnimateOnChange.test.js
@@ -2,9 +2,7 @@ import React from 'react'
 import { act } from 'react-dom/test-utils'
 import { mount } from 'enzyme'
 import AnimateOnChange from './'
-/*
-jest.useFakeTimers()
-*/
+
 describe('AnimateOnChange', () => {
   it('should render child value', () => {
     const component = mount(<AnimateOnChange>123</AnimateOnChange>)
@@ -44,7 +42,7 @@ describe('AnimateOnChange', () => {
 
   it('should animate then change content when children changes', () => {
     const component = mount(<AnimateOnChange>old</AnimateOnChange>)
-    component.simulate('transitionEnd');
+    component.simulate('transitionEnd')
     expect(component.find('span').get(0).props.style.opacity).toEqual(1)
     expect(component.text()).toEqual('old')
 
@@ -62,16 +60,10 @@ describe('AnimateOnChange', () => {
     expect(component.text()).toEqual('old')
 
     // Test opacity and new value after duration has passed
-/*
-    act(() => {
-      jest.runAllTimers()
-    })
-*/
-
     act(() => {
       component.update()
     })
-    component.simulate('transitionEnd');
+    component.simulate('transitionEnd')
 
     expect(component.find('span').get(0).props.style.opacity).toEqual(1)
     expect(component.text()).toEqual('new')
@@ -83,6 +75,7 @@ describe('AnimateOnChange', () => {
         old
       </AnimateOnChange>
     )
+    component.simulate('transitionEnd')
     expect(component.find('span').get(0).props.style.animation).toEqual(
       undefined
     )
@@ -100,15 +93,11 @@ describe('AnimateOnChange', () => {
       expect.stringContaining('pop-out')
     )
     expect(component.text()).toEqual('old')
-/*
-    act(() => {
-      jest.runAllTimers()
-    })
-*/
+
     act(() => {
       component.update()
     })
-    component.simulate('transitionEnd');
+    component.simulate('transitionEnd')
 
     expect(component.find('span').get(0).props.style.animation).toEqual(
       expect.stringContaining('pop-in')
@@ -122,6 +111,7 @@ describe('AnimateOnChange', () => {
         old
       </AnimateOnChange>
     )
+    component.simulate('transitionEnd')
     expect(component.find('span').get(0).props.style.animation).toEqual(
       undefined
     )
@@ -137,15 +127,11 @@ describe('AnimateOnChange', () => {
     expect(component.find('span').get(0).props.style.animation).toEqual(
       expect.stringContaining('out test')
     )
-/*
-    act(() => {
-      jest.runAllTimers()
-    })
-*/
+
     act(() => {
       component.update()
     })
-    component.simulate('transitionEnd');
+    component.simulate('transitionEnd')
 
     expect(component.find('span').get(0).props.style.animation).toEqual(
       expect.stringContaining('in test')
@@ -155,6 +141,7 @@ describe('AnimateOnChange', () => {
   it('should set default class names on in and out', () => {
     const className = 'animate-on-change'
     const component = mount(<AnimateOnChange>old</AnimateOnChange>)
+    component.simulate('transitionEnd')
     expect(component.find('span').get(0).props.className).toEqual(
       expect.stringContaining(className)
     )
@@ -179,15 +166,11 @@ describe('AnimateOnChange', () => {
     expect(component.find('span').get(0).props.className).not.toEqual(
       expect.stringContaining(`${className}-in`)
     )
-/*
-    act(() => {
-      jest.runAllTimers()
-    })
-*/
+
     act(() => {
       component.update()
     })
-    component.simulate('transitionEnd');
+    component.simulate('transitionEnd')
 
     expect(component.find('span').get(0).props.className).not.toEqual(
       expect.stringContaining(`${className}-out`)
@@ -202,6 +185,7 @@ describe('AnimateOnChange', () => {
     const component = mount(
       <AnimateOnChange className={className}>old</AnimateOnChange>
     )
+    component.simulate('transitionEnd')
     expect(component.find('span').get(0).props.className).toEqual(
       expect.stringContaining(className)
     )
@@ -226,11 +210,7 @@ describe('AnimateOnChange', () => {
     expect(component.find('span').get(0).props.className).not.toEqual(
       expect.stringContaining(`${className}-in`)
     )
-/*
-    act(() => {
-      jest.runAllTimers()
-    })
-*/
+
     act(() => {
       component.update()
     })
@@ -257,9 +237,6 @@ describe('AnimateOnChange', () => {
     act(() => {
       component.unmount()
     })
-/*
-    expect(clearTimeout).toHaveBeenCalledTimes(1)
-*/
   })
 
   it('should accept custom styles', () => {

--- a/src/AnimateOnChange/index.js
+++ b/src/AnimateOnChange/index.js
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useState, useRef } from 'react'
+import React, { useEffect, /*useLayoutEffect, */useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { animations } from '../theme'
 import '../theme/keyframes.css'
@@ -27,26 +27,24 @@ const AnimateOnChange = ({
   const [displayContent, setDisplayContent] = useState(children)
   const firstUpdate = useRef(true)
 
-  useLayoutEffect(
+  useEffect(
     () => {
       // Don't run the effect the first time through
       if (firstUpdate.current) {
         firstUpdate.current = false
         return
       }
-
       setAnimation('out')
-      const timeout = setTimeout(() => {
-        setAnimation('in')
-        setDisplayContent(children)
-      }, durationOut)
-
-      return () => {
-        clearTimeout(timeout)
-      }
     },
     [children]
   )
+
+  const showDisplayContent = () => {
+    if (animation === 'out') {
+      setAnimation('in')
+      setDisplayContent(children)
+    }
+  }
 
   const styles = {
     display: 'inline-block',
@@ -66,6 +64,8 @@ const AnimateOnChange = ({
 
   return (
     <span
+      onTransitionEnd={showDisplayContent}
+      onAnimationEnd={showDisplayContent}
       className={`${className || 'animate-on-change'} ${className ||
         'animate-on-change'}-${animation}`}
       style={styles}

--- a/src/AnimateOnChange/index.js
+++ b/src/AnimateOnChange/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, /*useLayoutEffect, */useState, useRef } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { animations } from '../theme'
 import '../theme/keyframes.css'

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -11,7 +11,8 @@ module.exports = merge(commonConfig, {
     library: 'ReactAnimation',
     libraryTarget: 'umd',
     publicPath: '/dist/',
-    umdNamedDefine: true
+    umdNamedDefine: true,
+    globalObject: 'this'
   },
   externals: {
     // Don't bundle react or react-dom


### PR DESCRIPTION
# Changes in this PR

## Use ontransitionend/onanimationend events instead of timeout (#11)

* The change uses react synthetic events instead of attaching event handlers directly to the DOM, as suggested in the ticket;
* Biggest impact of the change is to the unit tests, as enzyme doesn't automatically fire the necessary events. Instead, `component.simulate('transitionEnd')` has to be used to manually fire the events at the appropriate time;
* The positioning of the `simulate()` function calls within the test code is critical, as the tests will not pass if the events are simulated in the wrong place. When modifying the test code, `simulate()` calls have been placed in the following places:
  * immediately after calls to `mount()`;
  * immediately after any call to `component.update()` which occurs after a call to `runAllTimers()`
* All timer code has been removed from the unit test.

## Replace useLayoutEffect with useEffect (#12)

* There's no discernable difference between using `useEffect` and `useLayoutEffect`, unit tests pass in both cases and the animations seem to work fine in the browser
* So the call to `useLayoutEffect` has been replaced with a call to `useEffect`

## Use 'this' as global instead of 'window' (#16)

* The webpack `globalObject` config setting allows the global object name to be changed from `window` to `this`
* The change should work fine for normal library usage; `this` will resolve to `window` in a browser context, and to `global` in a node.js context.

## Bumped version number to 1.1.0

* Minor version number has been increased.
